### PR TITLE
Implement pay-credits prompts for trashing accessed cards and traces

### DIFF
--- a/src/clj/game/cards.clj
+++ b/src/clj/game/cards.clj
@@ -212,20 +212,31 @@
   ([provider-func] (pick-credit-providing-cards provider-func (hash-map) 0 nil))
   ([provider-func target-count] (pick-credit-providing-cards provider-func (hash-map) 0 target-count))
   ([provider-func selected-cards counter-count target-count]
-   (let [pay-rest (req (if (pos? target-count)
-                         (do
-                           (deduct state side [:credit (- target-count counter-count)])
-                           (swap! state update-in [:stats side :spent :credit] (fnil + 0) target-count)
-                           (let [msg (str (join ", " (map #(let [{:keys [card number]} %
-                                                                 title (:title card)]
-                                                             (str number " [Credits] from " title))
-                                                          (vals selected-cards)))
-                                          (let [remainder (- target-count counter-count)]
-                                            (when (pos? remainder) (str " and " remainder " [Credits]"))))]
-                             (when-let [card (some #(when (has-subtype? (:card %) "Stealth") (:card %)) (vals selected-cards))]
-                               (trigger-event state side :spent-stealth-credit card)
-                             (effect-completed state side (make-result eid {:number counter-count :msg msg})))))
-                         (effect-completed state side 0)))]
+   (let [pay-rest
+         (req (if (<= (- target-count counter-count) (get-in @state [side :credit]))
+                (let [remainder (- target-count counter-count)
+                      remainder-str (when (pos? remainder)
+                                      (str remainder " [Credits]"))
+                      card-strs (when (pos? (count selected-cards))
+                                  (str (join ", " (map #(let [{:keys [card number]} %
+                                                              title (:title card)]
+                                                          (str number " [Credits] from " title))
+                                                       (vals selected-cards)))))
+                      message (str card-strs
+                                   (when (and card-strs remainder-str)
+                                     " and ")
+                                   remainder-str
+                                   (when (and card-strs remainder-str)
+                                     " from their credit pool"))]
+                  (deduct state side [:credit remainder])
+                  (swap! state update-in [:stats side :spent :credit] (fnil + 0) target-count)
+                  (when-let [card (some #(when (has-subtype? (:card %) "Stealth") (:card %)) (vals selected-cards))]
+                    (trigger-event state side :spent-stealth-credit card))
+                  (effect-completed state side (make-result eid {:number counter-count :msg message})))
+                (continue-ability
+                  state side
+                  (pick-credit-providing-cards provider-func selected-cards counter-count target-count)
+                  card nil)))]
      (let [provider-cards (provider-func)]
        (if (or (not (pos? target-count))        ; there is a limit
                (>= counter-count target-count)  ; paid everything

--- a/src/clj/game/cards/assets.clj
+++ b/src/clj/game/cards/assets.clj
@@ -1295,7 +1295,9 @@
 
    "Net Police"
    {:recurring (effect (set-prop card :rec-counter (:link runner)))
-    :effect (effect (set-prop card :rec-counter (:link runner)))}
+    :effect (effect (set-prop card :rec-counter (:link runner)))
+    :interactions {:pay-credits {:req (req (= :trace (:source-type eid)))
+                                 :type :recurring}}}
 
    "Neurostasis"
    (advance-ambush 3 {:req (req (pos? (get-counters (get-card state card) :advancement)))
@@ -1466,7 +1468,9 @@
                        (continue-ability state side (pdhelper agendas 0) card nil)))}}})
 
    "Primary Transmission Dish"
-   {:recurring 3}
+   {:recurring 3
+    :interactions {:pay-credits {:req (req (= :trace (:source-type eid)))
+                                 :type :recurring}}}
 
    "Private Contracts"
    {:effect (effect (add-counter card :credit 14))

--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -394,7 +394,7 @@
               :effect (req (let [c target
                                  cost (:cost c)
                                  title (:title c)]
-                             (if (can-pay? state :corp nil :credit cost)
+                             (if (can-pay? state :corp eid card nil :credit cost)
                                (do (show-wait-prompt state :runner "Corp to decide whether or not to prevent the trash")
                                    (continue-ability
                                      state :corp
@@ -934,7 +934,7 @@
              state side
              {:prompt "Install a program?"
               :choices (conj (vec (sort-by :title (filter #(and (is-type? % "Program")
-                                                                (can-pay? state side nil
+                                                                (can-pay? state side eid card nil
                                                                           (modified-install-cost state side % [:credit -5])))
                                                           topten))) "No install")
               :async true
@@ -1545,7 +1545,7 @@
                       {:player :corp
                        :async true
                        :prompt "Pay 5 [Credits] or take 1 Bad Publicity?"
-                       :choices (concat (when (can-pay? state :corp "Mining Accident" :credit 5)
+                       :choices (concat (when (can-pay? state :corp eid card "Mining Accident" :credit 5)
                                           ["Pay 5 [Credits]"])
                                         ["Take 1 Bad Publicity"])
                        :effect (req (clear-wait-prompt state :runner)
@@ -1899,17 +1899,17 @@
                                        (installed? %))}
                   :effect (req (move state side target :hand)
                                (effect-completed state side (make-result eid (:cost target))))}
-         put-down (fn [st si bonus]
+         put-down (fn [st si eid card bonus]
                     {:async true
                      :prompt "Select a program or piece of hardware to install"
                      :choices {:req #(and (valid-target? %)
-                                          (can-pay? st si nil (modified-install-cost st si % [:credit (- bonus)])))}
+                                          (can-pay? st si eid card nil (modified-install-cost st si % [:credit (- bonus)])))}
                      :effect (effect (install-cost-bonus [:credit (- bonus)])
                                      (runner-install eid target nil))})]
      {:req (req (some valid-target? (all-installed state :runner)))
       :effect (req (wait-for (resolve-ability state side pick-up card nil)
                              (continue-ability state side
-                                               (put-down state side async-result)
+                                               (put-down state side eid card async-result)
                                                card nil)))})
 
    "Reshape"
@@ -2043,7 +2043,11 @@
    {:prompt "Select an installed program to trash"
     :choices {:req #(and (is-type? % "Program")
                          (installed? %))}
-    :effect (req (let [trashed target tcost (- (:cost trashed)) st state si side]
+    :effect (req (let [trashed target tcost (- (:cost trashed))
+                       st state
+                       si side
+                       e eid
+                       c card]
                    (trash state side trashed)
                    (resolve-ability
                      state side
@@ -2051,7 +2055,7 @@
                       :show-discard true
                       :choices {:req #(and (is-type? % "Program")
                                            (#{[:hand] [:discard]} (:zone %))
-                                           (can-pay? st si nil (modified-install-cost st si % [:credit tcost])))}
+                                           (can-pay? st si e c nil (modified-install-cost st si % [:credit tcost])))}
                       :effect (effect (install-cost-bonus [:credit (- (:cost trashed))])
                                       (runner-install target))
                       :msg (msg "trash " (:title trashed) " and install " (:title target))} card nil)))}

--- a/src/clj/game/cards/ice.clj
+++ b/src/clj/game/cards/ice.clj
@@ -1101,7 +1101,7 @@
                    :prompt "How many advancement tokens?"
                    :choices (req (map str (range (inc (min 2 (:credit corp))))))
                    :effect (req (let [c (str->int target)]
-                                  (if (can-pay? state side (:title card) :credit c)
+                                  (if (can-pay? state side eid card (:title card) :credit c)
                                     (do (pay state :corp card :credit c)
                                         (continue-ability
                                           state side
@@ -2486,7 +2486,7 @@
                                   :prompt "Choose one"
                                   :choices ["Lose [Click]" "End the run"]
                                   :effect (req (if-not (and (= target "Lose [Click]")
-                                                            (can-pay? state :runner nil [:click 1]))
+                                                            (can-pay? state :runner eid card nil [:click 1]))
                                                  (do (end-run state side)
                                                      (system-msg state side "ends the run"))
                                                  (do (lose state side :click 1)

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -52,7 +52,7 @@
                          :yes-ability
                          {:async true
                           :effect (req (clear-wait-prompt state :corp)
-                                       (if (not (can-pay? state :corp nil :credit 1))
+                                       (if (not (can-pay? state :corp eid card nil :credit 1))
                                          (do
                                            (toast state :corp "Cannot afford to pay 1 credit to block card exposure" "info")
                                            (expose state :runner eid itarget))
@@ -1371,7 +1371,10 @@
                               :req (req (has-subtype? target "Transaction"))}}}
 
    "Whizzard: Master Gamer"
-   {:recurring 3}
+   {:recurring 3
+    :interactions {:pay-credits {:req (req (and (= :runner-trash-corp-cards (:source-type eid))
+                                                (corp? target)))
+                                 :type :recurring}}}
 
    "Wyvern: Chemically Enhanced"
    {:events {:pre-start-game {:effect draft-points-target}

--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -917,7 +917,9 @@
     :abilities [(set-autoresolve :auto-ctm "CtM")]}
 
    "NBN: Making News"
-   {:recurring 2}
+   {:recurring 2
+    :interactions {:pay-credits {:req (req (= :trace (:source-type eid)))
+                                 :type :recurring}}}
 
    "NBN: The World is Yours*"
    {:effect (effect (gain :hand-size 1))

--- a/src/clj/game/cards/operations.clj
+++ b/src/clj/game/cards/operations.clj
@@ -513,7 +513,7 @@
 
    "Economic Warfare"
    {:req (req (and (last-turn? state :runner :successful-run)
-                   (can-pay? state :runner nil :credit 4)))
+                   (can-pay? state :runner eid card nil :credit 4)))
     :msg "make the runner lose 4 [Credits]"
     :effect (effect (lose-credits :runner 4))}
 
@@ -673,7 +673,7 @@
                         :prompt "Pay how many credits?"
                         :choices {:number (req numtargets)}
                         :effect (req (let [c target]
-                                       (if (can-pay? state side (:title card) :credit c)
+                                       (if (can-pay? state side eid card (:title card) :credit c)
                                          (do (pay state :corp card :credit c)
                                              (continue-ability
                                                state :corp
@@ -1314,7 +1314,7 @@
     :prompt "Pay how many credits?"
     :choices {:number (req (count-tags state))}
     :effect (req (let [c target]
-                   (if (can-pay? state side (:title card) :credit c)
+                   (if (can-pay? state side eid card (:title card) :credit c)
                      (do (pay state :corp card :credit c)
                          (continue-ability
                            state side

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -310,7 +310,7 @@
    "Algernon"
    {:events
     {:runner-turn-begins
-     {:req (req (can-pay? state :runner nil [:credit 2]))
+     {:req (req (can-pay? state :runner eid card nil [:credit 2]))
       :optional
       {:prompt (msg "Pay 2 [Credits] to gain [Click]")
        :player :runner
@@ -760,10 +760,10 @@
                      (continue-ability state side (custsec-host from) card nil)))
       :abilities [{:cost [:click 1]
                    :prompt "Choose a program hosted on Customized Secretary to install"
-                   :choices (req (cancellable (filter #(can-pay? state side nil :credit (:cost %))
+                   :choices (req (cancellable (filter #(can-pay? state side eid card nil :credit (:cost %))
                                                       (:hosted card))))
                    :msg (msg "install " (:title target))
-                   :effect (req (when (can-pay? state side nil :credit (:cost target))
+                   :effect (req (when (can-pay? state side eid card nil :credit (:cost target))
                                   (runner-install state side target)))}]})
 
    "Cyber-Cypher"
@@ -1710,7 +1710,10 @@
               :msg (msg "trash " (:title target))}}}
 
    "Paricia"
-   {:recurring 2}
+   {:recurring 2
+    :interactions {:pay-credits {:req (req (and (= :runner-trash-corp-cards (:source-type eid))
+                                                (asset? target)))
+                                 :type :recurring}}}
 
    "Passport"
    (central-breaker "Code Gate"

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -506,7 +506,7 @@
    "Councilman"
    {:implementation "Does not restrict Runner to Asset / Upgrade just rezzed"
     :events {:rez {:req (req (and (#{"Asset" "Upgrade"} (:type target))
-                                  (can-pay? state :runner nil [:credit (rez-cost state :corp target)])))
+                                  (can-pay? state :runner eid card nil [:credit (rez-cost state :corp target)])))
                    :effect (req (toast state :runner (str "Click Councilman to derez " (card-str state target {:visible true})
                                                           " that was just rezzed") "info")
                                 (toast state :corp (str "Runner has the opportunity to derez with Councilman.") "error"))}}
@@ -515,7 +515,7 @@
                                       (or (is-type? % "Asset") (is-type? % "Upgrade")))}
                  :effect (req (let [c target
                                     creds (rez-cost state :corp c)]
-                                (when (can-pay? state side nil [:credit creds])
+                                (when (can-pay? state side eid card nil [:credit creds])
                                   (resolve-ability
                                     state :runner
                                     {:msg (msg "pay " creds " [Credit] and derez " (:title c) ". Councilman is trashed")
@@ -919,7 +919,7 @@
      (effect (show-wait-prompt :corp "Runner to take decision on Fencer Fueno")
              (continue-ability
                {:prompt "Pay 1 [Credits] or trash Fencer Fueno?"
-                :choices (req (if (can-pay? state :runner nil :credit 1)
+                :choices (req (if (can-pay? state :runner eid card nil :credit 1)
                                 ["Pay 1 [Credits]" "Trash"]
                                 ["Trash"]))
                 :player :runner
@@ -1385,7 +1385,9 @@
 
    "Miss Bones"
    {:data {:counter {:credit 12}}
-    :implementation "Credit use restriction not enforced"
+    :interactions {:pay-credits {:req (req (and (= :runner-trash-corp-cards (:source-type eid))
+                                                (installed? target)))
+                                 :type :credit}}
     :abilities [{:counter-cost [:credit 1]
                  :msg "gain 1 [Credits] for trashing installed cards"
                  :async true
@@ -1535,7 +1537,7 @@
                                    {:cost [:click 1]
                                     :prompt "Select a connection in your Grip to install on Off-Campus Apartment"
                                     :choices {:req #(and (has-subtype? % "Connection")
-                                                         (can-pay? state side nil :credit (:cost %))
+                                                         (can-pay? state side eid card nil :credit (:cost %))
                                                          (in-hand? %))}
                                     :msg (msg "host " (:title target) " and draw 1 card")
                                     :effect (effect (runner-install target {:host-card card}))}
@@ -1718,7 +1720,7 @@
                  :choices {:req #(and (:trash %)
                                       (rezzed? %))}
                  :effect (req (let [cost (modified-trash-cost state :runner target)]
-                                (when (can-pay? state side nil [:credit cost])
+                                (when (can-pay? state side eid card nil [:credit cost])
                                   (resolve-ability
                                     state side
                                     {:msg (msg "pay " cost " [Credit] and trash " (:title target))
@@ -1787,7 +1789,7 @@
                                                             (is-type? % "Hardware")
                                                             (and (is-type? % "Resource")
                                                                  (has-subtype? % "Virtual")))
-                                                        (can-pay? state :runner nil (:cost %)))
+                                                        (can-pay? state :runner eid card nil (:cost %)))
                                                   (:discard runner))
                                           :sorted))
                           :msg (msg "install " (:title target) " from the Heap")
@@ -1901,7 +1903,7 @@
     :abilities [{:label "Remove the currently accessed card from the game instead of trashing it"
                  :req (req (let [c (:card (first (get-in @state [:runner :prompt])))]
                              (if-let [trash-cost (trash-cost state side c)]
-                               (if (can-pay? state :runner nil :credit trash-cost)
+                               (if (can-pay? state :runner eid card nil :credit trash-cost)
                                  (if (:slums-active card)
                                    true
                                    ((toast state :runner "Can only use a copy of Salsette Slums once per turn.") false))
@@ -1961,7 +1963,10 @@
                  :effect (effect (trash card {:cause :ability-cost}) (play-instant target))}]}
 
    "Scrubber"
-   {:recurring 2}
+   {:recurring 2
+    :interactions {:pay-credits {:req (req (and (= :runner-trash-corp-cards (:source-type eid))
+                                                (corp? target)))
+                                 :type :recurring}}}
 
    "Security Testing"
    (let [ability {:prompt "Choose a server for Security Testing"
@@ -2036,11 +2041,11 @@
                  :prompt "Choose a card on Street Peddler to install"
                  :choices (req (cancellable (filter #(and (not (is-type? % "Event"))
                                                           (runner-can-install? state side % nil)
-                                                          (can-pay? state side nil (modified-install-cost state side % [:credit -1])))
+                                                          (can-pay? state side eid card nil (modified-install-cost state side % [:credit -1])))
                                                     (:hosted card))))
                  :msg (msg "install " (:title target) " lowering its install cost by 1 [Credits]")
                  :effect (req
-                           (when (can-pay? state side nil (modified-install-cost state side target [:credit -1]))
+                           (when (can-pay? state side eid card nil (modified-install-cost state side target [:credit -1]))
                              (install-cost-bonus state side [:credit -1])
                              (trash state side (update-in card [:hosted]
                                                           (fn [coll]
@@ -2268,14 +2273,14 @@
    "The Supplier"
    (let [ability {:label "Install a hosted card (start of turn)"
                   :prompt "Choose a card hosted on The Supplier to install"
-                  :req (req (some #(can-pay? state side nil (modified-install-cost state side % [:credit -2]))
+                  :req (req (some #(can-pay? state side eid card nil (modified-install-cost state side % [:credit -2]))
                                   (:hosted card)))
                   :choices {:req #(and (= "The Supplier" (:title (:host %)))
                                        (= "Runner" (:side %)))}
                   :once :per-turn
                   :effect (req
                             (runner-can-install? state side target nil)
-                            (when (and (can-pay? state side nil (modified-install-cost state side target [:credit -2]))
+                            (when (and (can-pay? state side eid card nil (modified-install-cost state side target [:credit -2]))
                                        (not (and (:uniqueness target) (in-play? state target))))
                               (install-cost-bonus state side [:credit -2])
                               (runner-install state side target)
@@ -2337,7 +2342,7 @@
                   :async true
                   :prompt (msg "Select a card to install with Thunder Art Gallery")
                   :effect (req (if (and (runner-can-install? state side target)
-                                        (can-pay? state side target
+                                        (can-pay? state side eid card target
                                                   (install-cost state side target [:credit (dec (:cost target))])))
                                  (do (install-cost-bonus state side [:credit -1])
                                      (system-msg state side "uses Thunder Art Gallery to install a card.")

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -497,7 +497,9 @@
    {:recurring 1
     :events {:rez {:req (req (ice? target))
                    :msg "gain 1 [Credits]"
-                   :effect (effect (gain-credits :runner 1))}}}
+                   :effect (effect (gain-credits :runner 1))}}
+    :interactions {:pay-credits {:req (req (= :trace (:source-type eid)))
+                                 :type :recurring}}}
 
    "Corporate Defector"
    {:events {:corp-click-draw {:msg (msg "reveal " (-> target first :title))

--- a/src/clj/game/cards/upgrades.clj
+++ b/src/clj/game/cards/upgrades.clj
@@ -844,7 +844,7 @@
              :effect (req (let [trash-cost (trash-cost state side card)
                                 no-salsette (remove #(= (:title %) "Salsette Slums") (all-active state :runner))
                                 slow-trash (any-flag-fn? state :runner :slow-trash true no-salsette)]
-                            (if (and (can-pay? state :runner nil :credit trash-cost)
+                            (if (and (can-pay? state :runner eid card nil :credit trash-cost)
                                      (not slow-trash))
                               (do (toast state :runner "You have been forced to trash Mumbad Virtual Tour" "info")
                                   (swap! state assoc-in [:runner :register :force-trash] true))
@@ -1261,7 +1261,7 @@
       :req (req (and this-server
                      (= target :net)
                      (pos? (last targets))
-                     (can-pay? state :corp nil [:credit 2])))
+                     (can-pay? state :corp eid card nil [:credit 2])))
       :effect (req (swap! state assoc-in [:damage :damage-replace] true)
                    (damage-defer state side :net (last targets))
                    (show-wait-prompt state :runner "Corp to use Tori Hanzō")

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -165,7 +165,7 @@
   [state side {:keys [eid] :as ability} card targets]
   (when-let [trace (:trace ability)]
     (if (can-trigger? state side ability card targets)
-      (init-trace state side card (assoc trace :eid (:eid ability)))
+      (init-trace state side eid card trace)
       (effect-completed state side eid))))
 
 (defn- do-choices
@@ -363,9 +363,13 @@
   ([state side card message f args] (show-trace-prompt state side (make-eid state) card message f args))
   ([state side eid card message f {:keys [priority player other base bonus strength link] :as args}]
    (let [prompt (if (string? message) message (message state side nil card nil))
+         corp-credits (total-available-credits state :corp eid card)
+         runner-credits (total-available-credits state :runner eid card)
          newitem {:eid eid
                   :msg prompt
-                  :choices :credit
+                  :choices (if (= :corp side) corp-credits runner-credits)
+                  :corp-credits corp-credits
+                  :runner-credits runner-credits
                   :prompt-type :trace
                   :effect f
                   :card card
@@ -525,8 +529,7 @@
 
 (defn resolve-trace
   "Compares trace strength and link strength and triggers the appropriate effects."
-  [state side card {:keys [eid player other base bonus link priority ability strength] :as trace} boost]
-  (clear-wait-prompt state :corp)
+  [state side eid card {:keys [player other base bonus link priority ability strength] :as trace} boost]
   (let [corp-strength (if (corp-start? trace)
                         strength
                         ((fnil + 0 0 0) base bonus boost))
@@ -534,61 +537,64 @@
                           ((fnil + 0 0) link boost)
                           strength)
         trigger-trace (select-keys trace [:player :other :base :bonus :link :priority :ability :strength])]
-    (system-msg state other (str " spends " boost
-                                 " [Credits] to increase " (if (corp-start? trace) "link" "trace")
-                                 " strength to " (if (corp-start? trace)
-                                                   runner-strength
-                                                   corp-strength)))
-    (clear-wait-prompt state player)
-    (let [successful (> corp-strength runner-strength)
-          which-ability (assoc (if successful
-                                 (:successful trace)
-                                 (:unsuccessful trace))
-                               :eid (make-eid state))]
-      (system-say state player (str "The trace was " (when-not successful "un") "successful."))
-      (wait-for (trigger-event-simult state :corp (if successful :successful-trace :unsuccessful-trace)
-                                      nil ;; No special functions
-                                      (assoc trigger-trace
-                                             :corp-strength corp-strength
-                                             :runner-strength runner-strength
-                                             :successful successful
-                                             :corp-spent (if (corp-start? trace)
-                                                           (- strength base bonus)
-                                                           boost)
-                                             :runner-spent (if (corp-start? trace)
-                                                             boost
-                                                             (- strength link))))
-                (wait-for (resolve-ability state :corp (:eid which-ability) which-ability
-                                           card [corp-strength runner-strength])
-                          (if-let [kicker (:kicker trace)]
-                            (if (>= corp-strength (:min kicker))
-                              (continue-ability state :corp kicker card [corp-strength runner-strength])
-                              (effect-completed state side eid))
-                            (effect-completed state side eid)))))))
+    (wait-for (pay-sync state other (make-eid state eid) card [:credit boost])
+              (system-msg state other (str " spends " boost
+                                           " [Credits] to increase " (if (corp-start? trace) "link" "trace")
+                                           " strength to " (if (corp-start? trace)
+                                                             runner-strength
+                                                             corp-strength)))
+              (clear-wait-prompt state player)
+              (let [successful (> corp-strength runner-strength)
+                    which-ability (assoc (if successful
+                                           (:successful trace)
+                                           (:unsuccessful trace))
+                                         :eid (make-eid state))]
+                (system-say state player (str "The trace was " (when-not successful "un") "successful."))
+                (wait-for (trigger-event-simult state :corp (if successful :successful-trace :unsuccessful-trace)
+                                                nil ;; No special functions
+                                                (assoc trigger-trace
+                                                       :corp-strength corp-strength
+                                                       :runner-strength runner-strength
+                                                       :successful successful
+                                                       :corp-spent (if (corp-start? trace)
+                                                                     (- strength base bonus)
+                                                                     boost)
+                                                       :runner-spent (if (corp-start? trace)
+                                                                       boost
+                                                                       (- strength link))))
+                          (wait-for (resolve-ability state :corp (:eid which-ability) which-ability
+                                                     card [corp-strength runner-strength])
+                                    (if-let [kicker (:kicker trace)]
+                                      (if (>= corp-strength (:min kicker))
+                                        (continue-ability state :corp kicker card [corp-strength runner-strength])
+                                        (effect-completed state side eid))
+                                      (effect-completed state side eid))))))))
 
 (defn trace-reply
   "Shows a trace prompt to the second player, after the first has already spent credits to boost."
-  [state side card {:keys [eid player other base bonus link priority] :as trace} boost]
+  [state side eid card {:keys [player other base bonus link priority] :as trace} boost]
   (let [other-type (if (corp-start? trace) "link" "trace")
         strength (if (corp-start? trace)
                    ((fnil + 0 0 0) base bonus boost)
                    ((fnil + 0 0) link boost))
         trace (assoc trace :strength strength)]
-    (system-msg state player (str " spends " boost
-                                  "[Credits] to increase " (if (corp-start? trace) "trace" "link")
-                                  " strength to " strength))
-    (clear-wait-prompt state other)
-    (show-wait-prompt state player
-                      (str (if (corp-start? trace) "Runner" "Corp")
-                           " to boost " other-type " strength")
-                      {:priority priority})
-    (show-trace-prompt state other card (str "Boost " other-type " strength?")
-                       #(resolve-trace state side card trace %)
-                       trace)))
+    (wait-for (pay-sync state player (make-eid state eid) card [:credit boost])
+              (system-msg state player (str " spends " boost
+                                            "[Credits] to increase " (if (corp-start? trace) "trace" "link")
+                                            " strength to " strength))
+              (clear-wait-prompt state other)
+              (show-wait-prompt state player
+                                (str (if (corp-start? trace) "Runner" "Corp")
+                                     " to boost " other-type " strength")
+                                {:priority priority})
+              (show-trace-prompt state other (make-eid state eid) card
+                                 (str "Boost " other-type " strength?")
+                                 #(resolve-trace state side eid card trace %)
+                                 trace))))
 
 (defn trace-start
   "Starts the trace process by showing the boost prompt to the first player (normally corp)."
-  [state side card {:keys [player other base bonus priority label] :as trace}]
+  [state side eid card {:keys [player other base bonus priority label] :as trace}]
   (let [this-type (if (corp-start? trace) "trace" "link")]
     (system-msg state player (str "uses " (:title card)
                                   " to initiate a trace with strength " ((fnil + 0 0) base bonus)
@@ -600,9 +606,9 @@
                       (str (if (corp-start? trace) "Corp" "Runner")
                            " to boost " this-type " strength")
                       {:priority priority})
-    (show-trace-prompt state player card
+    (show-trace-prompt state player (make-eid state eid) card
                        (str "Boost " this-type " strength?")
-                       #(trace-reply state side card trace %)
+                       #(trace-reply state side eid card trace %)
                        trace)))
 
 (defn reset-trace-modifications
@@ -611,24 +617,28 @@
   (swap! state dissoc-in [:bonus :trace]))
 
 (defn init-trace
-  [state side card {:keys [base priority eid] :as trace}]
-  (reset-trace-modifications state)
-  (wait-for (trigger-event-sync state :corp :pre-init-trace card eid)
-            (let [force-base (get-in @state [:trace :force-base])
-                  force-link (get-in @state [:trace :force-link])
-                  base (cond force-base force-base
-                             (fn? base) (base state :corp (make-eid state) card nil)
-                             :else base)
-                  link (or force-link
-                           (get-in @state [:runner :link] 0))
-                  initiator (determine-initiator state trace)
-                  trace (merge trace {:player initiator
-                                      :other (if (= :corp initiator) :runner :corp)
-                                      :base base
-                                      :bonus (get-in @state [:bonus :trace] 0)
-                                      :link link
-                                      :priority (or priority 2)})]
-              (trace-start state side card trace))))
+  ([state side card] (init-trace state side (make-eid state {:source-type :trace}) card {:base 0}))
+  ([state side card trace] (init-trace state side (make-eid state {:source-type :trace}) card trace))
+  ([state side eid card {:keys [base priority] :as trace}]
+   (reset-trace-modifications state)
+   (wait-for (trigger-event-sync state :corp :pre-init-trace card eid)
+             (let [force-base (get-in @state [:trace :force-base])
+                   force-link (get-in @state [:trace :force-link])
+                   base (cond force-base force-base
+                              (fn? base) (base state :corp (make-eid state) card nil)
+                              :else base)
+                   link (or force-link
+                            (get-in @state [:runner :link] 0))
+                   bonus (get-in @state [:bonus :trace] 0)
+                   initiator (determine-initiator state trace)
+                   eid (assoc eid :source-type :trace)
+                   trace (merge trace {:player initiator
+                                       :other (if (= :corp initiator) :runner :corp)
+                                       :base base
+                                       :bonus bonus
+                                       :link link
+                                       :priority (or priority 2)})]
+               (trace-start state side eid card trace)))))
 
 (defn rfg-and-shuffle-rd-effect
   ([state side card n] (rfg-and-shuffle-rd-effect state side (make-eid state) card n false))

--- a/src/clj/game/core/abilities.clj
+++ b/src/clj/game/core/abilities.clj
@@ -284,7 +284,7 @@
              (let [yes-ability (:yes-ability ability)]
                (if (and (= prompt-choice "Yes")
                         yes-ability
-                        (can-pay? state side (:title card) (:cost yes-ability)))
+                        (can-pay? state side eid card (:title card) (:cost yes-ability)))
                  (resolve-ability state side (assoc yes-ability :eid eid) card targets)
                  (if-let [no-ability (:no-ability ability)]
                    (resolve-ability state side (assoc no-ability :eid eid) card targets)

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -199,6 +199,7 @@
 
       ;; Integer prompts
       (or (= choices :credit)
+          (= :trace (:prompt-type prompt))
           (:counter choices)
           (:number choices))
       (if (number? choice)

--- a/src/clj/game/core/actions.clj
+++ b/src/clj/game/core/actions.clj
@@ -280,8 +280,8 @@
   (let [cost (:cost ability)]
     (when (or (nil? cost)
               (if (has-subtype? card "Run")
-                (apply can-pay? state side (:title card) cost (run-costs state side card))
-                (apply can-pay? state side (:title card) cost)))
+                (can-pay? state side (make-eid state) card (:title card) cost (run-costs state side card))
+                (can-pay? state side (make-eid state) card (:title card) cost)))
       (when-let [activatemsg (:activatemsg ability)]
         (system-msg state side activatemsg))
       (resolve-ability state side ability card targets))))
@@ -376,7 +376,7 @@
              cdef-sub (get-in cdef [:subroutines cdef-idx])
              cost (:cost cdef-sub)]
          (when (or (nil? cost)
-                   (apply can-pay? state side (:title card) cost))
+                   (can-pay? state side eid card (:title card) cost))
            (when-let [activatemsg (:activatemsg cdef-sub)] (system-msg state side activatemsg))
            (resolve-ability state side eid cdef-sub card targets)))
        (when-let [sub-card (find-latest state {:cid (:from-cid sub) :side side})]
@@ -429,12 +429,12 @@
          (if (or (#{"Asset" "ICE" "Upgrade"} (:type card))
                    (:install-rezzed (card-def card)))
            (do (trigger-event state side :pre-rez-cost card)
-               (if (and altcost (can-pay? state side nil altcost)(not ignore-cost))
+               (if (and altcost (can-pay? state side eid card nil altcost) (not ignore-cost))
                  (let [curr-bonus (get-rez-cost-bonus state side)]
                    (prompt! state side card (str "Pay the alternative Rez cost?") ["Yes" "No"]
                             {:async true
                              :effect (req (if (and (= target "Yes")
-                                                   (can-pay? state side (:title card) altcost))
+                                                   (can-pay? state side eid card (:title card) altcost))
                                             (do (pay state side card altcost)
                                                 (rez state side eid (-> card (dissoc :alternative-cost))
                                                      (merge args {:ignore-cost true

--- a/src/clj/game/core/costs.clj
+++ b/src/clj/game/core/costs.clj
@@ -2,7 +2,8 @@
 
 (declare forfeit prompt! toast damage mill installed? is-type? is-scored? system-msg
          facedown? make-result unknown->kw discard-from-hand card-str trash trash-cards
-         complete-with-result all-installed-runner-type pick-credit-providing-cards all-active)
+         complete-with-result all-installed-runner-type pick-credit-providing-cards all-active
+         eligible-pay-credit-cards)
 
 (defn deduct
   "Deduct the value from the player's attribute."
@@ -48,7 +49,7 @@
 
 (defn toast-msg-helper
   "Creates a toast message for given cost and title if applicable"
-  [state side cost]
+  [state side eid card cost]
   (let [cost-type (first cost)
         amount (last cost)
         computer-says-no "Unable to pay"]
@@ -69,8 +70,14 @@
                (and (= cost-type :connection)
                     (<= 0 (- (count (filter #(has-subtype? % "Connection") (all-active-installed state :runner))) amount)))
                (and (= cost-type :shuffle-installed-to-stack) (<= 0 (- (count (all-installed state :runner)) amount)))
-               (and (#{:credit :click} cost-type)
-                    (<= 0 (- (get-in @state [side cost-type] -1) amount)))))
+               (and (= cost-type :click) (<= 0 (- (get-in @state [side :click]) amount)))
+               (and (= cost-type :credit)
+                    (or (<= 0 (- (get-in @state [side :credit]) amount))
+                        (<= 0 (+ (- (get-in @state [side :credit]) amount)
+                                 (->> (eligible-pay-credit-cards state side eid card)
+                                      (map #(+ (get-counters % :recurring)
+                                               (get-counters % :credit)))
+                                      (reduce +))))))))
       computer-says-no)))
 
 (defn add-default-to-costs
@@ -118,23 +125,14 @@
   "Returns false if the player cannot pay the cost args, or a truthy map otherwise.
   If title is specified a toast will be generated if the player is unable to pay
   explaining which cost they were unable to pay."
-  [state side title & args]
-  (let [costs (merge-costs (remove #(or (nil? %) (map? %)) args))
-        cost-msg (some #(toast-msg-helper state side %) costs)]
-    ;; no cost message - hence can pay
-    (if-not cost-msg
-      costs
-      (when title (toast state side (str cost-msg " for " title ".")) false))))
-
-(defn can-pay-with-recurring?
-  "Returns true if the player can pay the cost factoring in available recurring credits"
-  [state side cost]
-  (>= (+ (- (get-in @state [side :credit] -1) cost)
-         (->> (all-installed state side)
-              (map #(+ (get-counters % :recurring)
-                       (get-counters % :credit)))
-              (reduce +)))
-      0))
+  ([state side title args] (can-pay? state side (make-eid state) nil title args))
+  ([state side eid card title & args]
+   (let [costs (merge-costs (remove #(or (nil? %) (map? %)) args))
+         cost-msg (some #(toast-msg-helper state side eid card %) costs)]
+     ;; no cost message - hence can pay
+     (if-not cost-msg
+       costs
+       (when title (toast state side (str cost-msg " for " title ".")) false)))))
 
 (defn- complete-with-result
   "Calls `effect-complete` with `make-result` and also returns the argument.
@@ -264,24 +262,29 @@
                 (str "trashes " (quantify amount "card") " randomly from "
                      (if (= :corp side) "HQ" "the grip"))))))
 
+(defn all-active-pay-credit-cards
+  [state side eid card]
+  (filter #(when-let [pc (-> % card-def :interactions :pay-credits)]
+             (if (:req pc)
+               ((:req pc) state side eid % [card])
+               true))
+          (all-active state side)))
+
+(defn eligible-pay-credit-cards
+  [state side eid card]
+  (filter
+    #(case (-> % card-def :interactions :pay-credits :type)
+       :recurring
+       (pos? (get-counters (get-card state %) :recurring))
+       :credit
+       (pos? (get-counters (get-card state %) :credit))
+       :custom
+       true)
+    (all-active-pay-credit-cards state side eid card)))
+
 (defn pay-credits
   [state side eid card amount]
-  (let [provider-cards (filter
-                         #(when-let [pc (-> % card-def :interactions :pay-credits)]
-                            (if (:req pc)
-                              ((:req pc) state side eid % [card])
-                              true))
-                         (all-active state side))
-        provider-func (fn []
-                        (filter
-                          #(case (-> % card-def :interactions :pay-credits :type)
-                             :recurring
-                             (pos? (get-counters (get-card state %) :recurring))
-                             :credit
-                             (pos? (get-counters (get-card state %) :credit))
-                             :custom
-                             true)
-                          provider-cards))]
+  (let [provider-func #(eligible-pay-credit-cards state side eid card)]
     (if (and (pos? amount)
              (pos? (count (provider-func))))
       (wait-for (resolve-ability state side (pick-credit-providing-cards provider-func amount) card nil)
@@ -351,7 +354,7 @@
   [state side card & args]
   (let [raw-costs (not-empty (remove map? args))
         action (not-empty (filter map? args))]
-    (when-let [costs (apply can-pay? state side (:title card) raw-costs)]
+    (when-let [costs (can-pay? state side (:title card) raw-costs)]
         (->> costs
              (map (partial cost-handler state side (make-eid state) card action costs))
              (filter some?)
@@ -370,7 +373,7 @@
   [state side eid card & args]
   (let [raw-costs (not-empty (remove map? args))
         action (not-empty (filter map? args))]
-    (if-let [costs (apply can-pay? state side (:title card) raw-costs)]
+    (if-let [costs (can-pay? state side eid card (:title card) raw-costs)]
       (wait-for (pay-sync-next state side (make-eid state eid) costs card action [])
                 (complete-with-result state side eid (->> async-result
                                                           (filter some?)

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -19,7 +19,7 @@
                (swap! state update-in [:bonus] dissoc :run-cost)
                (if (and (can-run? state :runner)
                         (can-run-server? state server)
-                        (can-pay? state :runner "a run" all-run-costs))
+                        (can-pay? state :runner (make-eid state eid) card "a run" all-run-costs))
                  (do (when (= card :click-run)
                        (swap! state assoc-in [:runner :register :click-type] :run)
                        (swap! state assoc-in [:runner :register :made-click-run] true)
@@ -79,6 +79,7 @@
              ;; Don't increment :no-trash-or-steal if accessing a card in Archives
              (not= (:zone c) [:discard]))
     (swap! state update-in [:runner :register :no-trash-or-steal] (fnil inc 0)))
+  (swap! state dissoc :access)
   (trigger-event-sync state side eid :post-access-card c))
 
 ;;; Stealing agendas
@@ -158,9 +159,10 @@
     ;; The card has a trash cost (Asset, Upgrade)
     (let [card (assoc c :seen true)
           card-name (:title card)
-          trash-cost (trash-cost state side c)
-          can-pay (when trash-cost (can-pay? state :runner nil :credit trash-cost))
-          pay-with-recurring (when trash-cost (can-pay-with-recurring? state :runner trash-cost))]
+          trash-cost (trash-cost state side card)
+          trash-eid (assoc eid :source card :source-type :runner-trash-corp-cards)
+          can-pay (when trash-cost
+                    (can-pay? state :runner trash-eid card nil [:credit trash-cost]))]
       ;; Show the option to pay to trash the card.
       (when-not (and (is-type? card "Operation")
                      ;; Don't show the option if Edward Kim's auto-trash flag is true.
@@ -171,7 +173,7 @@
                                        (concat (all-active state :runner)
                                                (get-in @state [:runner :play-area])))
                 ability-strs (map #(get-in (card-def %) [:interactions :trash-ability :label]) trash-ab-cards)
-                trash-cost-str (when (or can-pay pay-with-recurring)
+                trash-cost-str (when can-pay
                                  [(str "Pay " trash-cost " [Credits] to trash")])
                 ;; If the runner is forced to trash this card (Neutralize All Threats)
                 forced-to-trash? (and (or can-pay
@@ -191,23 +193,19 @@
                :prompt (str "You accessed " card-name ".")
                :choices choices
                :effect (req (cond
-                              (= target "No action")
+                              (= target (first no-action-str))
                               (access-end state side eid c)
 
-                              (.contains target "Pay")
-                              (if (> trash-cost (get-in @state [:runner :credit] 0))
-                                (do (toast state side (str "You don't have the credits to pay for " card-name
-                                                           ". Did you mean to first gain credits from installed cards?"))
-                                    (access-non-agenda state side eid c :skip-trigger-event true))
-                                (do (lose state side :credit trash-cost)
-                                    (when (:run @state)
-                                      (swap! state assoc-in [:run :did-trash] true)
-                                      (when forced-to-trash?
-                                        (swap! state assoc-in [:run :did-access] true)))
-                                    (swap! state assoc-in [:runner :register :trashed-card] true)
-                                    (system-msg state side pay-str)
-                                    (wait-for (trash state side card nil)
-                                              (access-end state side eid c))))
+                              (= target (first trash-cost-str))
+                              (wait-for (pay-sync state side (make-eid state trash-eid) card [:credit trash-cost])
+                                        (when (:run @state)
+                                          (swap! state assoc-in [:run :did-trash] true)
+                                          (when forced-to-trash?
+                                            (swap! state assoc-in [:run :did-access] true)))
+                                        (swap! state assoc-in [:runner :register :trashed-card] true)
+                                        (system-msg state side (str async-result " to trash " card-name))
+                                        (wait-for (trash state side card nil)
+                                                  (access-end state side eid c)))
 
                               (some #(= % target) ability-strs)
                               (let [idx (.indexOf ability-strs target)
@@ -239,7 +237,7 @@
         part-cost (partition 2 cost)
         cost-strs (when (seq part-cost) (map #(apply cost-names %) part-cost))
         card-name (:title c)
-        can-pay-costs? (can-pay? state side card-name cost)
+        can-pay-costs? (can-pay? state side (make-eid state eid) c card-name cost)
         ;; any trash abilities
         can-steal-this? (can-steal? state side c)
         trash-ab-cards (when (not= (:zone c) [:discard])
@@ -940,7 +938,6 @@
     (swap! state assoc-in [:runner :run-credit] 0)
     (swap! state assoc :run nil)
     (update-all-ice state side)
-    (swap! state dissoc :access)
     (clear-run-register! state)
     (trigger-run-end-events state side (:eid run) run)))
 

--- a/src/cljs/nr/gameboard.cljs
+++ b/src/cljs/nr/gameboard.cljs
@@ -1328,8 +1328,8 @@
                                                 {:choice (-> "#credit" js/$ .val str->int)})}
               "OK"]]
             (cond
-              ;; choice of number of credits
-              (= (:choices prompt) "credit")
+              ;; trace prompts require their own logic
+              (= (:prompt-type prompt) "trace")
               [:div
                (when-let [base (:base prompt)]
                  ;; This is the initial trace prompt
@@ -1337,10 +1337,10 @@
                    (if (= "corp" (:player prompt))
                      ;; This is a trace prompt for the corp, show runner link + credits
                      [:div.info "Runner: " (:link prompt) [:span {:class "anr-icon link"}]
-                      " + " (:credit @runner) [:span {:class "anr-icon credit"}]]
+                      " + " (:runner-credits prompt) [:span {:class "anr-icon credit"}]]
                      ;; Trace in which the runner pays first, showing base trace strength and corp credits
                      [:div.info "Trace: " (when (:bonus prompt) (+ base (:bonus prompt)) base)
-                      " + " (:credit @corp) [:span {:class "anr-icon credit"}]])
+                      " + " (:corp-credits prompt) [:span {:class "anr-icon credit"}]])
                    ;; This is a trace prompt for the responder to the trace, show strength
                    (if (= "corp" (:player prompt))
                      [:div.info "vs Trace: " (:strength prompt)]
@@ -1357,6 +1357,16 @@
                       [:span (:link prompt) " " [:span {:class "anr-icon link"}] (str " + " )]
                       (let [strength (when (:bonus prompt) (+ base (:bonus prompt)) base)]
                         [:span (str strength " + ")]))))
+                [:select#credit (for [i (range (inc (:choices prompt)))]
+                                  [:option {:value i :key i} i])] " credits"]
+               [:button {:on-click #(send-command "choice"
+                                                  {:choice (-> "#credit" js/$ .val str->int)})}
+                "OK"]]
+
+              ;; choice of number of credits
+              (= (:choices prompt) "credit")
+              [:div
+               [:div.credit-select
                 [:select#credit (for [i (range (inc (:credit @me)))]
                                   [:option {:value i :key i} i])] " credits"]
                [:button {:on-click #(send-command "choice"

--- a/test/clj/game_test/cards/assets.clj
+++ b/test/clj/game_test/cards/assets.clj
@@ -2570,35 +2570,47 @@
 
 (deftest ngo-front
   ;; NGO Front - full test
-  (do-game
-    (new-game {:corp {:deck [(qty "NGO Front" 3)]}})
-    (core/gain state :corp :click 3)
-    (play-from-hand state :corp "NGO Front" "New remote")
-    (play-from-hand state :corp "NGO Front" "New remote")
-    (play-from-hand state :corp "NGO Front" "New remote")
-    (let [ngo1 (get-content state :remote1 0)
-          ngo2 (get-content state :remote2 0)
-          ngo3 (get-content state :remote3 0)]
-      (core/advance state :corp {:card ngo2})
-      (core/advance state :corp {:card (refresh ngo3)})
-      (core/advance state :corp {:card (refresh ngo3)})
-      (core/rez state :corp (refresh ngo1))
-      (core/rez state :corp (refresh ngo2))
-      (core/rez state :corp (refresh ngo3))
-      (is (= 2 (:credit (get-corp))) "Corp at 2 credits")
-      (card-ability state :corp ngo1 1)
-      (card-ability state :corp ngo1 0)
-      (is (= 2 (:credit (get-corp))) "Corp still 2 credits")
-      (is (zero? (count (:discard (get-corp)))) "Nothing trashed")
-      (card-ability state :corp ngo2 1)
-      (is (= 2 (:credit (get-corp))) "Corp still 2 credits")
-      (is (zero? (count (:discard (get-corp)))) "Nothing trashed")
-      (card-ability state :corp ngo2 0)
-      (is (= 7 (:credit (get-corp))) "Corp gained 5 credits")
-      (is (= 1 (count (:discard (get-corp)))) "1 NGO Front Trashed")
-      (card-ability state :corp ngo3 1)
-      (is (= 15 (:credit (get-corp))) "Corp gained 8 credits")
-      (is (= 2 (count (:discard (get-corp)))) "2 NGO Front Trashed"))))
+  (testing "Basic test"
+    (do-game
+      (new-game {:corp {:deck [(qty "NGO Front" 3)]}})
+      (core/gain state :corp :click 3)
+      (play-from-hand state :corp "NGO Front" "New remote")
+      (play-from-hand state :corp "NGO Front" "New remote")
+      (play-from-hand state :corp "NGO Front" "New remote")
+      (let [ngo1 (get-content state :remote1 0)
+            ngo2 (get-content state :remote2 0)
+            ngo3 (get-content state :remote3 0)]
+        (advance state ngo2)
+        (advance state (refresh ngo3))
+        (advance state (refresh ngo3))
+        (core/rez state :corp (refresh ngo1))
+        (core/rez state :corp (refresh ngo2))
+        (core/rez state :corp (refresh ngo3))
+        (is (= 2 (:credit (get-corp))) "Corp at 2 credits")
+        (card-ability state :corp ngo1 1)
+        (card-ability state :corp ngo1 0)
+        (is (= 2 (:credit (get-corp))) "Corp still 2 credits")
+        (is (zero? (count (:discard (get-corp)))) "Nothing trashed")
+        (card-ability state :corp ngo2 1)
+        (is (= 2 (:credit (get-corp))) "Corp still 2 credits")
+        (is (zero? (count (:discard (get-corp)))) "Nothing trashed")
+        (card-ability state :corp ngo2 0)
+        (is (= 7 (:credit (get-corp))) "Corp gained 5 credits")
+        (is (= 1 (count (:discard (get-corp)))) "1 NGO Front Trashed")
+        (card-ability state :corp ngo3 1)
+        (is (= 15 (:credit (get-corp))) "Corp gained 8 credits")
+        (is (= 2 (count (:discard (get-corp)))) "2 NGO Front Trashed"))))
+  (testing "Run ends when used mid-run"
+    (do-game
+      (new-game {:corp {:deck ["NGO Front"]}})
+      (play-from-hand state :corp "NGO Front" "New remote")
+      (let [ngo (get-content state :remote1 0)]
+        (advance state ngo)
+        (take-credits state :corp)
+        (run-on state :remote1)
+        (card-ability state :corp ngo 0)
+        (is (nil? (refresh ngo)))
+        (is (nil? (:run @state)))))))
 
 (deftest open-forum
   ;; Open Forum

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -1517,6 +1517,22 @@
     (is (= 7 (count (:hand (get-runner)))) "Drew 2 cards from successful run on Archives")
     (is (= 1 (count-tags state)) "Took 1 tag from successful run on Archives")))
 
+(deftest nbn-making-news
+  ;; NBN: Making News
+  (do-game
+    (new-game {:corp {:id "NBN: Making News"
+                      :deck [(qty "Hedge Fund" 5)]
+                      :hand ["Snatch and Grab"]}})
+    (let [nbn-mn (:identity (get-corp))]
+      (play-from-hand state :corp "Snatch and Grab")
+      (is (= (+ (:credit (get-corp)) (get-counters (refresh nbn-mn) :recurring))
+             (:choices (prompt-map :corp))) "7 total available credits for the trace")
+      (click-prompt state :corp "7")
+      (dotimes [_ 2]
+        (click-card state :corp nbn-mn))
+      (is (zero? (get-counters (refresh nbn-mn) :recurring)) "Has used recurring credit")
+      (is (= 10 (:strength (prompt-map :runner))) "Current trace strength should be 10"))))
+
 (deftest maxx-maximum-punk-rock
   ;; MaxX
   (testing "Basic test"

--- a/test/clj/game_test/cards/identities.clj
+++ b/test/clj/game_test/cards/identities.clj
@@ -2424,17 +2424,23 @@
           (is (= 2 (count (:discard (get-runner)))) "Runner took 2 meat damage from BoN/Cleaners combo"))))))
 
 (deftest whizzard-master-gamer
-  ;; Whizzard - Recurring credits
+  ;; Whizzard
   (do-game
-    (new-game {:runner {:id "Whizzard: Master Gamer"
-                        :deck ["Sure Gamble"]}})
-    (let [click-whizzard (fn [n] (dotimes [i n] (card-ability state :runner (:identity (get-runner)) 0)))]
-      (is (changes-credits (get-runner) 1 (click-whizzard 1)))
-      (is (changes-credits (get-runner) 2 (click-whizzard 5)) "Can't take more than 3 Whizzard credits")
-      (take-credits state :corp)
-      (is (changes-credits (get-runner) 3 (click-whizzard 3)) "Credits reset at start of Runner's turn")
-      (take-credits state :runner)
-      (is (changes-credits (get-runner) 0 (click-whizzard 1)) "Credits don't reset at start of Corp's turn"))))
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["PAD Campaign" "Shell Corporation"]}
+               :runner {:id "Whizzard: Master Gamer"
+                        :credits 1}})
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (take-credits state :corp)
+    (let [pad (get-content state :remote1 0)
+          whiz (:identity (get-runner))]
+      (run-on state :remote1)
+      (run-successful state)
+      (is (= 1 (:credit (get-runner))) "Runner can't afford to trash PAD Campaign")
+      (click-prompt state :runner "Pay 4 [Credits] to trash")
+      (dotimes [_ 3]
+        (click-card state :runner (refresh whiz)))
+      (is (nil? (refresh pad)) "PAD Campaign successfully trashed"))))
 
 (deftest wyvern-chemically-enhanced
   ;; Wyvern: Chemically Enhanced

--- a/test/clj/game_test/cards/programs.clj
+++ b/test/clj/game_test/cards/programs.clj
@@ -1598,6 +1598,32 @@
           (is (= 1 (count (:discard (get-corp)))) "Enigma trashed")
           (is (= 1 (count (:discard (get-runner)))) "Parasite trashed when Enigma was trashed"))))))
 
+(deftest paricia
+  ;; Paricia
+  (do-game
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["PAD Campaign" "Shell Corporation"]}
+               :runner {:hand ["Paricia"]}})
+    (play-from-hand state :corp "PAD Campaign" "New remote")
+    (play-from-hand state :corp "Shell Corporation" "New remote")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Paricia")
+    (let [pad (get-content state :remote1 0)
+          shell (get-content state :remote2 0)
+          paricia (get-program state 0)]
+      (run-on state :remote2)
+      (run-successful state)
+      (click-prompt state :runner "Pay 3 [Credits] to trash")
+      (is (empty? (:prompt (get-runner))) "No pay-credit prompt as it's an upgrade")
+      (is (nil? (refresh shell)) "Shell Corporation successfully trashed")
+      (run-on state :remote1)
+      (run-successful state)
+      (is (= 2 (:credit (get-runner))) "Runner can't afford to trash PAD Campaign")
+      (click-prompt state :runner "Pay 4 [Credits] to trash")
+      (dotimes [_ 2]
+        (click-card state :runner "Paricia"))
+      (is (nil? (refresh pad)) "PAD Campaign successfully trashed"))))
+
 (deftest pelangi
   ;; Pelangi
   (do-game

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -433,7 +433,8 @@
 (deftest compromised-employee
   ;; Compromised Employee - Gain 1c every time Corp rezzes ICE
   (do-game
-    (new-game {:corp {:deck [(qty "Pup" 2) "Launch Campaign"]}
+    (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                      :hand ["Snatch and Grab" (qty "Pup" 2) "Launch Campaign"]}
                :runner {:deck ["Compromised Employee"]}})
     (play-from-hand state :corp "Pup" "HQ")
     (play-from-hand state :corp "Pup" "R&D")
@@ -447,7 +448,16 @@
       (core/rez state :corp (get-ice state :rd 0))
       (is (= 5 (:credit (get-runner))) "Gained 1c from ICE rez")
       (core/rez state :corp (get-content state :remote1 0))
-      (is (= 5 (:credit (get-runner))) "Asset rezzed, no credit gained"))))
+      (is (= 5 (:credit (get-runner))) "Asset rezzed, no credit gained")
+      (take-credits state :runner)
+      (play-from-hand state :corp "Snatch and Grab")
+      (click-prompt state :corp "0")
+      (is (= (+ (:credit (get-runner)) (get-counters (refresh ce) :recurring))
+             (:choices (prompt-map :runner))) "9 total available credits for the trace")
+      (click-prompt state :runner "9")
+      (dotimes [_ 1]
+        (click-card state :runner ce))
+      (is (zero? (get-counters (refresh ce) :recurring)) "Has used recurring credit"))))
 
 (deftest councilman
   ;; Councilman reverses the rezz and prevents re-rezz

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -1887,21 +1887,39 @@
 
 (deftest miss-bones
   ;; Miss Bones - credits for trashing installed cards, trash when empty
-  (do-game
-    (new-game {:runner {:deck ["Miss Bones"]}})
-    (take-credits state :corp)
-    (play-from-hand state :runner "Miss Bones")
-    (let [mb (get-resource state 0)]
-      (is (= 12 (get-counters (refresh mb) :credit)) "Miss Bones starts with 12 credits")
-      (is (= 3 (:credit (get-runner))) "Runner starts with 3 credits")
-      (card-ability state :runner mb 0)
-      (is (= 11 (get-counters (refresh mb) :credit)) "Miss Bones loses a credit")
-      (is (= 4 (:credit (get-runner))) "Runner gains a credit")
-      (dotimes [_ 11]
-        (card-ability state :runner mb 0))
-      (is (= 1 (count (:discard (get-runner)))) "Miss Bones in discard pile")
-      (is (empty? (get-resource state)) "Miss Bones not installed")
-      (is (= 15 (:credit (get-runner))) "Runner gained all 12 credits from Miss Bones"))))
+  (testing "Taking credits directly works, and it self trashes when empty"
+    (do-game
+      (new-game {:runner {:deck ["Miss Bones"]}})
+      (take-credits state :corp)
+      (play-from-hand state :runner "Miss Bones")
+      (let [mb (get-resource state 0)]
+        (is (= 12 (get-counters (refresh mb) :credit)) "Miss Bones starts with 12 credits")
+        (is (= 3 (:credit (get-runner))) "Runner starts with 3 credits")
+        (card-ability state :runner mb 0)
+        (is (= 11 (get-counters (refresh mb) :credit)) "Miss Bones loses a credit")
+        (is (= 4 (:credit (get-runner))) "Runner gains a credit")
+        (dotimes [_ 11]
+          (card-ability state :runner mb 0))
+        (is (= 1 (count (:discard (get-runner)))) "Miss Bones in discard pile")
+        (is (empty? (get-resource state)) "Miss Bones not installed")
+        (is (= 15 (:credit (get-runner))) "Runner gained all 12 credits from Miss Bones"))))
+  (testing "Can be used mid-run in a trash-prompt"
+    (do-game
+      (new-game {:corp {:hand ["Broadcast Square"]
+                        :deck [(qty "Hedge Fund" 5)]}
+                 :runner {:hand ["Miss Bones"]}})
+      (play-from-hand state :corp "Broadcast Square" "New remote")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Miss Bones")
+      (let [bs (get-content state :remote1 0)
+            mb (get-resource state 0)]
+        (run-on state :remote1)
+        (run-successful state)
+        (click-prompt state :runner "Pay 5 [Credits] to trash")
+        (dotimes [_ 5]
+          (click-card state :runner "Miss Bones"))
+        (is (= 7 (get-counters (refresh mb) :credit)) "Miss Bones loses 5 credits")
+        (is (nil? (refresh bs)) "Broadcast Square has been trashed")))))
 
 (deftest muertos-gang-member
   ;; Muertos Gang Member - Install and Trash
@@ -2606,36 +2624,9 @@
       (is (= 5 (:credit (get-runner))) "Runner should only have 5 credits in pool")
       (run-empty-server state "Server 1")
       (is (= 2 (-> (get-runner) :prompt first :choices count)) "Runner can use Scrubber credits to trash")
-      (let [scrubber (get-resource state 0)]
-        (card-ability state :runner scrubber 0)
-        (card-ability state :runner scrubber 0))
       (click-prompt state :runner "Pay 7 [Credits] to trash")
-      (is (= 2 (:agenda-point (get-runner))) "Runner should trash The Board and gain 2 agenda points")))
-  (testing "when under trash cost but can up with recurring credits"
-    (do-game
-      (new-game {:corp {:deck ["The Board"]}
-                 :runner {:deck ["Scrubber" "Skulljack" "Sure Gamble"]}})
-      (play-from-hand state :corp "The Board" "New remote")
-      (take-credits state :corp)
-      (run-empty-server state "Server 1")
-      (is (= 1 (-> (get-runner) :prompt first :choices count)) "Runner doesn't have enough credits to trash")
-      (click-prompt state :runner "No action")
-      (play-from-hand state :runner "Scrubber")
-      (take-credits state :runner)
-      (take-credits state :corp)
-      (play-from-hand state :runner "Skulljack")
-      (core/gain state :runner :credit 1)
-      (is (= 4 (:credit (get-runner))) "Runner should only have 4 credits in pool")
-      (run-empty-server state "Server 1")
-      (is (= 6 (core/trash-cost state :runner (get-content state :remote1 0))) "The Board should cost 6 to trash")
-      (is (= 2 (-> (get-runner) :prompt first :choices count)) "Runner can use Scrubber credits to trash")
-      (click-prompt state :runner "Pay 6 [Credits] to trash") ;; Whoops, runner forgot to actually get the credits from Scrubber
-      (is (= 6 (core/trash-cost state :runner (get-content state :remote1 0))) "Skulljack shouldn't trigger a second time")
-      (is (= 2 (-> (get-runner) :prompt first :choices count)) "Runner can still use Scrubber credits the second time around")
-      (let [scrubber (get-resource state 0)]
-        (card-ability state :runner scrubber 0)
-        (card-ability state :runner scrubber 0))
-      (click-prompt state :runner "Pay 6 [Credits] to trash") ;; Now the runner has actually gained the Scrubber credits
+      (click-card state :runner "Scrubber")
+      (click-card state :runner "Scrubber")
       (is (= 2 (:agenda-point (get-runner))) "Runner should trash The Board and gain 2 agenda points"))))
 
 (deftest security-testing

--- a/test/clj/game_test/cards/upgrades.clj
+++ b/test/clj/game_test/cards/upgrades.clj
@@ -1278,9 +1278,7 @@
       (play-from-hand state :runner "Daily Casts")
       (is (= 2 (:credit (get-runner))) "Runner paid install costs")
       (run-empty-server state "Server 1")
-      (is (= ["Pay 5 [Credits] to trash" "No action"]
-             (-> (get-runner) :prompt first :choices))
-          "Runner is given the choice, as we don't know if they can afford it or not"))))
+      (is (= ["No action"] (-> (get-runner) :prompt first :choices)) "Runner is not given the choice"))))
 
 (deftest mwanza-city-grid
   ;; Mwanza City Grid - runner accesses 3 additional cards, gain 2C for each card accessed

--- a/test/clj/game_test/macros.clj
+++ b/test/clj/game_test/macros.clj
@@ -23,9 +23,9 @@
          ~'prompt-fmt (fn [side#]
                         (let [prompt# (~'prompt-map side#)
                               choices# (:choices prompt#)
-                              choices# (if (keyword? choices#)
-                                         [choices#]
-                                         (seq choices#))
+                              choices# (if (sequential? choices#)
+                                         choices#
+                                         [choices#])
                               prompt-type# (:prompt-type prompt#)]
                           (str (side-str side#) ": " (:msg prompt# "") "\n"
                                "Type: " (if (some? prompt-type#) prompt-type# "nil") "\n"

--- a/test/clj/game_test/utils.clj
+++ b/test/clj/game_test/utils.clj
@@ -72,6 +72,14 @@
         (is (number? (Integer/parseInt choice))
             (expect-type "number string" choice)))
 
+      (= :trace (:prompt-type prompt))
+      (let [int-choice (Integer/parseInt choice)
+            under (<= int-choice (:choices prompt))]
+        (when-not (and under
+                       (when under (core/resolve-prompt state side {:choice int-choice})))
+          (is under (str (side-str side) " expected to click [ "
+                         int-choice " ] but couldn't find it. Current prompt is: \n" prompt))))
+
       ;; List of card titles for auto-completion
       (:card-title choices)
       (when-not (core/resolve-prompt state side {:choice choice})


### PR DESCRIPTION
## Changelog

### Pay-Credits
* Cleaned up the `pay-rest` function:
  * Check to make sure however much is left to pay can actually be paid
  * Intelligently build message to note where each portion came from, including the credit pool
  * If unable to pay, force user to actually choose all necessary `pay-credit` credits

### Trashing
* Added functionality for Scrubber, Miss Bones, Whizzard, and Paricia
* Fixed a small issue with `:access @state` not being cleared in the right place
* Added `eid` and `card` to `can-pay?`, passing through to `toast-msg-helper` so credit checking can include the right recurring/placed credits
* Exported the two helper functions from `pay-credits` for use in other places
* Cleaned up `access-non-agenda` so it now correctly checks the true total number of credits, meaning we no longer have to guess for Mumbad Virtual Tour or similar cards
* Add/update tests for all affected cards

### Traces
* Refactor trace prompts to be awaitable
* Move trace payments into trace prompts, using `pay-sync`
* Add `pay-credits` to `show-trace-prompts`
* Update UI and test utilities to handle new prompt `:choices`
* Export `total-available-credits` from `toast-msg-helper`
* Added functionality for Compromised Employee, NBN: Making News, Net Police, and Primary Transmission Dish
* Add/update tests for all affected cards