### PR TITLE
Clean up custom pay-credit effects, cold read

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -315,16 +315,15 @@
       :prompt "Choose a server"
       :recurring 4
       :choices (req runnable-servers)
-      :events {:begin-run {:effect (req (swap! state assoc :cold-read-active true))}}
       :effect (req (let [c (move state side (assoc card :zone '(:discard)) :play-area {:force true})]
                      (card-init state side c {:resolve-effect false})
+                     (update! state side (assoc (get-card state c) :cold-read-active true))
                      (make-run state side (make-eid state) target
                                {:end-run {:async true
-                                          :effect (req (trash state side c)
-                                                       (swap! state dissoc :cold-read-active)
-                                                       (continue-ability state side end-effect card nil))}}
-                               c)))
-      :interactions {:pay-credits {:req (req (:cold-read-active @state))
+                                          :effect (effect (trash card)
+                                                          (continue-ability end-effect nil nil))}}
+                               (assoc c :cold-read-active true))))
+      :interactions {:pay-credits {:req (req (:cold-read-active card))
                                    :type :recurring}}})
 
    "Compile"

--- a/test/clj/game_test/cards/operations.clj
+++ b/test/clj/game_test/cards/operations.clj
@@ -2246,19 +2246,18 @@
      (is (= 7 (:credit (get-runner))) "Runner has 7 credits")
      (run-on state :archives)
      (is (= 6 (:credit (get-runner))) "Runner spends 1 credit to make a run")))
-  (doseq [c ["Stimhack" "Cold Read"]]
-    (testing "Interaction with temp credits"
-      (do-game
-       (new-game {:corp {:deck ["Service Outage"]}
-                  :runner {:deck [(qty c 3)]}})
-       (play-from-hand state :corp "Service Outage")
-       (take-credits state :corp)
-       (play-from-hand state :runner c)
-       (click-prompt state :runner "HQ")
-       (core/jack-out state :runner nil)
-       (is (= 4 (:credit (get-runner))) (str "An additional real cred spent, not " c " money"))
-       (run-on state "R&D")
-       (is (= 4 (:credit (get-runner))) "Second run fine")))))
+  (testing "Interaction with temp credits"
+    (do-game
+      (new-game {:corp {:deck ["Service Outage"]}
+                 :runner {:deck [(qty "Stimhack" 3)]}})
+      (play-from-hand state :corp "Service Outage")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Stimhack")
+      (click-prompt state :runner "HQ")
+      (run-jack-out state)
+      (is (= 4 (:credit (get-runner))) (str "An additional real cred spent, not Stimhack money"))
+      (run-on state "R&D")
+      (is (= 4 (:credit (get-runner))) "Second run fine"))))
 
 (deftest shipment-from-sansan
   ;; Shipment from SanSan - placing advancements


### PR DESCRIPTION
You'd mentioned not liking the double levels req :effect req :effect, so I thinned it by using `continue-ability` and treating `:custom` like an `:effect` ability. Will make things like this much cleaner in the future too. Also, because `case` defaults to last place or throws an error, I felt it best to remove the `:custom` catch.

I also cleaned up Cold Read's implementation to setting a flag on the card instead of setting a flag on `state`, and cleaned up the now irrelevant test.